### PR TITLE
Upgraded to kramdown-man 1.0.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 
-gem 'kramdown-man'
+gem 'kramdown-man', '~> 1.0'
 gem 'semver'

--- a/doc/man/git-standup.1.md
+++ b/doc/man/git-standup.1.md
@@ -11,10 +11,10 @@ Views all commits made in the last week.
 ## OPTIONS
 
 `-h`, `--help`
-    Prints help.
+: Prints help.
 
 `-v`, `--version`
-    Prints the version.
+: Prints the version.
 
 ## AUTHOR
 
@@ -22,4 +22,4 @@ Tom Scott [tubbo\@psychedeli.ca](mailto:tubbo\@psychedeli.ca).
 
 ## SEE ALSO
 
-git(1)
+[git(1)](man:git(1))

--- a/doc/template/man.md
+++ b/doc/template/man.md
@@ -11,10 +11,10 @@ Enter description of command here.
 ## OPTIONS
 
 `-h`, `--help`
-    Prints help.
+: Prints help.
 
 `-v`, `--version`
-    Prints the version.
+: Prints the version.
 
 ## AUTHOR
 
@@ -22,4 +22,4 @@ Tom Scott [tubbo\@psychedeli.ca](mailto:tubbo\@psychedeli.ca).
 
 ## SEE ALSO
 
-git(1)
+[git(1)](man:git(1))


### PR DESCRIPTION
* Upgrade to `kramdown-man` ~> 1.0.
* Use the new man page syntax, which uses definition lists for options and arguments.
* Properly link to the `git(1)` man page.